### PR TITLE
ISSUE-69: Sacar la parte del `mailto` directamente

### DIFF
--- a/pages/ListaDeCorreo/migración.rst
+++ b/pages/ListaDeCorreo/migración.rst
@@ -1,7 +1,7 @@
 Migrando la lista de correo
 ===========================
 
-1. --(Levantar nueva lista en usla, <<MailTo(pyar AT python DOT org DOT ar)>>)--
+1. --(Levantar nueva lista en usla, pyar AT python DOT org DOT ar)--
 1. --(Suscribir los admins a la lista nueva)-- (subscriptos los que pidieron/encontre)
 
     1. empezar a probar desde todos los webmails más usados (contar en la lista de suscriptores cuales son!)
@@ -24,7 +24,7 @@ Migrando la lista de correo
 
 1. Suscribir a todos a la lista nueva y en el mail de bienvenida informar la nueva dirección. Recordar que actualicen sus reglas de filtrado.
 1. Revisar que sigan funcionando los archivos que están suscriptos a la lista (grulic, gmane, etc)
-1. Crear un alias <<MailTo(pyar-obsoleta AT python DOT org DOT ar)>> y hacer que te rebote el mail con la dirección de la nueva lista
-1. Avisar a todo el mundo que <<MailTo(pyar AT decode DOT com DOT ar)>> no va más
-1. Apuntar <<MailTo(pyar AT decode DOT com DOT ar)>> a <<MailTo(pyar-obsoleta AT python DOT org DOT ar)>> para que rebote los mails hasta que decode desaparezca.
+1. Crear un alias pyar-obsoleta AT python DOT org DOT ar y hacer que te rebote el mail con la dirección de la nueva lista
+1. Avisar a todo el mundo que pyar AT decode DOT com DOT ar no va más
+1. Apuntar pyar AT decode DOT com DOT ar)>> a <<MailTo(pyar-obsoleta AT python DOT org DOT ar para que rebote los mails hasta que decode desaparezca.
 

--- a/pages/Proyectos/unmanualencadauniversidad.rst
+++ b/pages/Proyectos/unmanualencadauniversidad.rst
@@ -20,42 +20,42 @@ Si estas cerca o tenes alguna relación con una universidad que no tiene el Tuto
 .. csv-table::
 	:header:  Nombre del responsable,Email,Universidad[es],Estado
 
-	Sebastián Bassi,<<MailTo(  sbassi EN  gmail PUNTO com)>>,Universidad Nacional de Quilmes,(4) 005.13 ROS
-	Sebastián Bassi,<<MailTo(  sbassi EN  gmail PUNTO com)>>,UNNOBA,(3)
-	Martín Gaitán,<<MailTo(  gaitan EN  gmail PUNTO com)>>,Universidad Nacional de Córdoba,(4) http://biblio.efn.unc.edu.ar/cgi-bin/koha/opac-detail.pl?biblionumber=8459|Ref. 8459
-	Federico Vincenti,<<MailTo(  federicovincenti EN  gmail PUNTO com)>>,Universidad Católica de Santiago del Estero - Departamento Académico Rafaela,"(4) Tutorial de Python - Van Rossum, Guido. Nº 5.552"
-	Marcos Alcazar,<<MailTo(  marcos.alcazar EN  gmail PUNTO com)>>,UTN - Facultad Regional Mendoza,(4) Tutorial de Python. Nº 547
-	Adrian Pardini,<<MailTo(  pardo PUNTO bsso EN  gmail PUNTO com)>>,UNLP Ingeniería,(4) El tutorial de Python. http://biblio.ing.unlp.edu.ar/cgi-bin/koha/opac-detail.pl?bib=INGC-MON-017574|Ref. 519.682 VAN Bloque 4
-	Matías Herranz,<<MailTo(  matiasherranz EN  gmail PUNTO com)>>,UNC (Universidad Nacional de Córdoba),(3)
-	Ezequiel Chan,<<MailTo(  ezequielchan EN  gmail PUNTO com)>>,Universidad Nacional de Luján,(1)
-	Julian Cardonnet,<<MailTo(  jcardonnet EN  gmail PUNTO com)>>,Universidad Nacional del Centro - Ingenieria de Sistemas (Tandil),(1)
-	Manuel Aráoz,<<MailTo(  manuelaraoz EN  gmail PUNTO com)>>,ITBA,(1)
-	Juan José Conti,<<MailTo(  jjconti EN  gmail PUNTO com)>>,"UTN FRSF, UNL, UCSF",(1)
-	Jose Maria Schenone,<<MailTo(  jomax EN  filo.uba PUNTO ar)>>,Filosofia y Letras,(1)
-	Alejandro Autalan,<<MailTo(  alejandroautalan EN  gmail PUNTO com)>>,Universidad Nacional de Santiago del Estero (UNSE),(3)
-	Daniel Ceillan,<<MailTo(  codigodaniel EN  gmail PUNTO com)>>,Cri - Usal (Mar del Plata),(1)
-	Claudio Freire,<<MailTo(  klaussfreire EN  gmail PUNTO com)>>,UBA (ciudad universitaria),(1)
-	Samanta Fernandez,<<MailTo(  samanta.fernandez EN  gmail PUNTO com)>>,"UTN - FRCU (C. del Uruguay, Entre Ríos)",(2)
-	Juan Martin Muguerza,<<MailTo(  juanma EN  gnutn PUNTO org PUNTO ar)>>,UTN Facultad Regional Buenos Aires,(1)
-	Agustin Henze,<<MailTo(  agustinhenze EN  gmail PUNTO com)>>,UTN Regional Córdoba,(2)
-	Daniel F. Moisset,<<MailTo(  dmoisset EN  machinalis PUNTO com)>>,"FaMAF, Univ. Nac. de Córdoba",(4) 20351
-	Andres Pardini,<<MailTo(  unpardos EN  gmail PUNTO com)>>,UNLP facultad informatica,(1)
-	Santiago Banchero,<<MailTo(  santiagobanchero EN  gmail PUNTO com)>>,Universidad Nacional de Luján (Centro Regional Chivilcoy),(1)
-	Diego Gaspar,<<MailTo(  armandogaspar EN  gmail PUNTO com)>>,Universidad Nacional de Cuyo y otros,(1)
-	Gonzalo Fernandez,<<MailTo(  buurentriko EN  gmail PUNTO com)>>,Universidad Nacional de Rio Cuarto,(1)
-	Ignacio Fiandrino,<<MailTo(  tucumetal EN  gmail PUNTO com)>>,Universidad Nacional de Rio Cuarto,"(4) El tutorial de Python. Van Rossum, Guido. http://juanfilloy.bib.unrc.edu.ar/consulta/script/frame_bottom.php?termino=python&isdoc=true&idbibliografia=33258&titulo=El%20tutorial%20de%20python&bases=a:4:{i:0;s:5:""libro"";i:1;s:5:""tesis"";i:2;s:5:""trafi"";i:3;s:4:""unrc"";}|681.3.06 V 280"
-	Gonzalo Delgado,<<MailTo(  gonzalodel EN  gmail PUNTO com)>>,Universidad Nacional de Tucumán (Facultad de Ciencias Exactas y Tecnología); Universidad Tecnológica Nacional (Facultad Regional Tucumán),(1)
-	Alejandro Santos,<<MailTo(  alejolp EN  alejolp PUNTO com PUNTO ar)>>,UNLP,"(4) Van Rossum, Guido. Tutorial de Python. http://catalogo.info.unlp.edu.ar/cgi-bin/koha/opac-detail.pl?bib=2915|DIF-03497, DIF-03498"
-	Pereyra Carlos,<<MailTo(  pereyra-carlos EN  hotmail PUNTO com)>>,UTN FRLP,(1)
-	Rafael Moyano,<<MailTo(  moyanor EN  gmail PUNTO com)>>,Universidad Nacional de La Rioja,(4) 236 - Id. de libros: 15486 y 15487
-	Pablo Papes,<<MailTo(  pablopapes EN  gmail PUNTO com)>>,UTN FRCU,(1)
-	Manuel Muradás,<<MailTo(  mmuradas EN  dieresys PUNTO com PUNTO ar)>>,UADE,(2)
-	Manuel Muradás,<<MailTo(  mmuradas EN  dieresys PUNTO com PUNTO ar)>>,"""José Hernandez"" E.E.T. Nº7 de Avellaneda",(2)
-	Diego Mascialino,<<MailTo(  dmascialino EN  gmail PUNTO com)>>,"UBA - Facultad de Ingeniería, Biblioteca ""Ing Butty"" y Biblioteca del LABI",(3)
-	Marcelo Cazon,<<MailTo(  sandman PUNTO net EN gmail PUNTO com)>>,UNCa - Facultad de Tecnologia y Ciencias Aplicadas,(1)
-	Iván Truskalo,<<MailTo(  truskalo EN  gmail PUNTO com)>>,Universidad Nacional de La Pampa - Facultad de Cs. Exactas,(1)
-	Carlos A. Giménez,<<MailTo(  scire1905 EN  gmail PUNTO com)>>,Universidad Nacional del Nordeste - Facultad de Cs. Exactas,(1)
-	Alejandro M. Wechsler,<<MailTo( alew_mdq EN hotmail punto com)>>,Universidad Nacional de Mar del Plata - Facultad de Ingenieria,(1)
+	Sebastián Bassi,  sbassi EN  gmail PUNTO com,Universidad Nacional de Quilmes,(4) 005.13 ROS
+	Sebastián Bassi,  sbassi EN  gmail PUNTO com,UNNOBA,(3)
+	Martín Gaitán,  gaitan EN  gmail PUNTO com,Universidad Nacional de Córdoba,(4) http://biblio.efn.unc.edu.ar/cgi-bin/koha/opac-detail.pl?biblionumber=8459|Ref. 8459
+	Federico Vincenti,  federicovincenti EN  gmail PUNTO com,Universidad Católica de Santiago del Estero - Departamento Académico Rafaela,"(4) Tutorial de Python - Van Rossum, Guido. Nº 5.552"
+	Marcos Alcazar,  marcos.alcazar EN  gmail PUNTO com,UTN - Facultad Regional Mendoza,(4) Tutorial de Python. Nº 547
+	Adrian Pardini,  pardo PUNTO bsso EN  gmail PUNTO com,UNLP Ingeniería,(4) El tutorial de Python. http://biblio.ing.unlp.edu.ar/cgi-bin/koha/opac-detail.pl?bib=INGC-MON-017574|Ref. 519.682 VAN Bloque 4
+	Matías Herranz,  matiasherranz EN  gmail PUNTO com,UNC (Universidad Nacional de Córdoba),(3)
+	Ezequiel Chan,  ezequielchan EN  gmail PUNTO com,Universidad Nacional de Luján,(1)
+	Julian Cardonnet,  jcardonnet EN  gmail PUNTO com,Universidad Nacional del Centro - Ingenieria de Sistemas (Tandil),(1)
+	Manuel Aráoz,  manuelaraoz EN  gmail PUNTO com,ITBA,(1)
+	Juan José Conti,  jjconti EN  gmail PUNTO com,"UTN FRSF, UNL, UCSF",(1)
+	Jose Maria Schenone,  jomax EN  filo.uba PUNTO ar,Filosofia y Letras,(1)
+	Alejandro Autalan,  alejandroautalan EN  gmail PUNTO com,Universidad Nacional de Santiago del Estero (UNSE),(3)
+	Daniel Ceillan,  codigodaniel EN  gmail PUNTO com,Cri - Usal (Mar del Plata),(1)
+	Claudio Freire,  klaussfreire EN  gmail PUNTO com,UBA (ciudad universitaria),(1)
+	Samanta Fernandez,  samanta.fernandez EN  gmail PUNTO com,"UTN - FRCU (C. del Uruguay, Entre Ríos)",(2)
+	Juan Martin Muguerza,  juanma EN  gnutn PUNTO org PUNTO ar,UTN Facultad Regional Buenos Aires,(1)
+	Agustin Henze,  agustinhenze EN  gmail PUNTO com,UTN Regional Córdoba,(2)
+	Daniel F. Moisset,  dmoisset EN  machinalis PUNTO com,"FaMAF, Univ. Nac. de Córdoba",(4) 20351
+	Andres Pardini,  unpardos EN  gmail PUNTO com,UNLP facultad informatica,(1)
+	Santiago Banchero,  santiagobanchero EN  gmail PUNTO com,Universidad Nacional de Luján (Centro Regional Chivilcoy),(1)
+	Diego Gaspar,  armandogaspar EN  gmail PUNTO com,Universidad Nacional de Cuyo y otros,(1)
+	Gonzalo Fernandez,  buurentriko EN  gmail PUNTO com,Universidad Nacional de Rio Cuarto,(1)
+	Ignacio Fiandrino,  tucumetal EN  gmail PUNTO com,Universidad Nacional de Rio Cuarto,"(4) El tutorial de Python. Van Rossum, Guido. http://juanfilloy.bib.unrc.edu.ar/consulta/script/frame_bottom.php?termino=python&isdoc=true&idbibliografia=33258&titulo=El%20tutorial%20de%20python&bases=a:4:{i:0;s:5:""libro"";i:1;s:5:""tesis"";i:2;s:5:""trafi"";i:3;s:4:""unrc"";}|681.3.06 V 280"
+	Gonzalo Delgado,  gonzalodel EN  gmail PUNTO com,Universidad Nacional de Tucumán (Facultad de Ciencias Exactas y Tecnología); Universidad Tecnológica Nacional (Facultad Regional Tucumán),(1)
+	Alejandro Santos,  alejolp EN  alejolp PUNTO com PUNTO ar,UNLP,"(4) Van Rossum, Guido. Tutorial de Python. http://catalogo.info.unlp.edu.ar/cgi-bin/koha/opac-detail.pl?bib=2915|DIF-03497, DIF-03498"
+	Pereyra Carlos,  pereyra-carlos EN  hotmail PUNTO com,UTN FRLP,(1)
+	Rafael Moyano,  moyanor EN  gmail PUNTO com,Universidad Nacional de La Rioja,(4) 236 - Id. de libros: 15486 y 15487
+	Pablo Papes,  pablopapes EN  gmail PUNTO com,UTN FRCU,(1)
+	Manuel Muradás,  mmuradas EN  dieresys PUNTO com PUNTO ar,UADE,(2)
+	Manuel Muradás,  mmuradas EN  dieresys PUNTO com PUNTO ar,"""José Hernandez"" E.E.T. Nº7 de Avellaneda",(2)
+	Diego Mascialino,  dmascialino EN  gmail PUNTO com,"UBA - Facultad de Ingeniería, Biblioteca ""Ing Butty"" y Biblioteca del LABI",(3)
+	Marcelo Cazon,  sandman PUNTO net EN gmail PUNTO com,UNCa - Facultad de Tecnologia y Ciencias Aplicadas,(1)
+	Iván Truskalo,  truskalo EN  gmail PUNTO com,Universidad Nacional de La Pampa - Facultad de Cs. Exactas,(1)
+	Carlos A. Giménez,  scire1905 EN  gmail PUNTO com,Universidad Nacional del Nordeste - Facultad de Cs. Exactas,(1)
+	Alejandro M. Wechsler, alew_mdq EN hotmail punto com,Universidad Nacional de Mar del Plata - Facultad de Ingenieria,(1)
 
 .. _Tutorial de Python en español: http://docs.python.org.ar/tutorial/contenido.html
 

--- a/pages/PyConArgentina/2012/distribucionafiches.rst
+++ b/pages/PyConArgentina/2012/distribucionafiches.rst
@@ -24,42 +24,42 @@ Si estas cerca o tenes alguna relación con una universidad, empresa o instituci
 .. csv-table::
     :header: Nombre del responsable,Email,Universidad[es],Estado
 
-    Sebastián Bassi,<<MailTo(  sbassi EN  gmail PUNTO com)>>,Universidad Nacional de Quilmes
-    Sebastián Bassi,<<MailTo(  sbassi EN  gmail PUNTO com)>>,UNNOBA
-    Mariano Reingart,<<MailTo(  reingart EN  gmail PUNTO com)>>,Universidad de Morón
-    Mariano Reingart,<<MailTo(  reingart EN  gmail PUNTO com)>>,Instituto Superior Tecnológico Blaise Pascal
-    Martín Gaitán,<<MailTo(  gaitan EN  gmail PUNTO com)>>,Universidad Nacional de Córdoba
-    Federico Vincenti,<<MailTo(  federicovincenti EN  gmail PUNTO com)>>,Universidad Católica de Santiago del Estero - Departamento Académico Rafaela
-    Marcos Alcazar,<<MailTo(  marcos.alcazar EN  gmail PUNTO com)>>,UTN - Facultad Regional Mendoza
-    Adrian Pardini,<<MailTo(  pardo PUNTO bsso EN  gmail PUNTO com)>>,UNLP Ingeniería
-    Matías Herranz,<<MailTo(  matiasherranz EN  gmail PUNTO com)>>,UNC (Universidad Nacional de Córdoba)
-    Ezequiel Chan,<<MailTo(  ezequielchan EN  gmail PUNTO com)>>,Universidad Nacional de Luján
-    Julian Cardonnet,<<MailTo(  jcardonnet EN  gmail PUNTO com)>>,Universidad Nacional del Centro - Ingenieria de Sistemas (Tandil)
-    Manuel Aráoz,<<MailTo(  manuelaraoz EN  gmail PUNTO com)>>,ITBA
-    Juan José Conti,<<MailTo(  jjconti EN  gmail PUNTO com)>>,"UTN FRSF, UNL, UCSF"
-    Jose Maria Schenone,<<MailTo(  jomax EN  filo.uba PUNTO ar)>>,Filosofia y Letras
-    Alejandro Autalan,<<MailTo(  alejandroautalan EN  gmail PUNTO com)>>,Universidad Nacional de Santiago del Estero (UNSE)
-    Daniel Ceillan,<<MailTo(  codigodaniel EN  gmail PUNTO com)>>,Cri - Usal (Mar del Plata)
-    Claudio Freire,<<MailTo(  klaussfreire EN  gmail PUNTO com)>>,UBA (ciudad universitaria)
-    Samanta Fernandez,<<MailTo(  samanta.fernandez EN  gmail PUNTO com)>>,"UTN - FRCU (C. del Uruguay, Entre Ríos)"
-    Juan Martin Muguerza,<<MailTo(  juanma EN  gnutn PUNTO org PUNTO ar)>>,UTN Facultad Regional Buenos Aires
-    Agustin Henze,<<MailTo(  agustinhenze EN  gmail PUNTO com)>>,UTN Regional Córdoba
-    Daniel F. Moisset,<<MailTo(  dmoisset EN  machinalis PUNTO com)>>,"FaMAF, Univ. Nac. de Córdoba"
-    Andres Pardini,<<MailTo(  unpardos EN  gmail PUNTO com)>>,UNLP facultad informatica
-    Santiago Banchero,<<MailTo(  santiagobanchero EN  gmail PUNTO com)>>,Universidad Nacional de Luján (Centro Regional Chivilcoy)
-    Diego Gaspar,<<MailTo(  armandogaspar EN  gmail PUNTO com)>>,Universidad Nacional de Cuyo y otros
-    Gonzalo Fernandez,<<MailTo(  buurentriko EN  gmail PUNTO com)>>,Universidad Nacional de Rio Cuarto
-    Ignacio Fiandrino,<<MailTo(  tucumetal EN  gmail PUNTO com)>>,Universidad Nacional de Rio Cuarto
-    Gonzalo Delgado,<<MailTo(  gonzalodel EN  gmail PUNTO com)>>,Universidad Nacional de Tucumán (Facultad de Ciencias Exactas y Tecnología); Universidad Tecnológica Nacional (Facultad Regional Tucumán)
-    Alejandro Santos,<<MailTo(  alejolp EN  alejolp PUNTO com PUNTO ar)>>,UNLP
-    Pereyra Carlos,<<MailTo(  pereyra-carlos EN  hotmail PUNTO com)>>,UTN FRLP
-    Rafael Moyano,<<MailTo(  moyanor EN  gmail PUNTO com)>>,Universidad Nacional de La Rioja
-    Pablo Papes,<<MailTo(  pablopapes EN  gmail PUNTO com)>>,UTN FRCU
-    Manuel Muradás,<<MailTo(  mmuradas EN  dieresys PUNTO com PUNTO ar)>>,UADE
-    Manuel Muradás,<<MailTo(  mmuradas EN  dieresys PUNTO com PUNTO ar)>>,"""José Hernandez"" E.E.T. Nº7 de Avellaneda"
-    Diego Mascialino,<<MailTo(  dmascialino EN  gmail PUNTO com)>>,"UBA - Facultad de Ingeniería, Biblioteca ""Ing Butty"" y Biblioteca del LABI"
-    Emiliano López,<<MailTo(  emiliano.lopez EN  gmail PUNTO com)>>,"Universidad Nacional del Litoral (SFe) - Facultad de Ingeniería y Ciencias Hídricas, Facultad de Ingeniería Química"
-    Marcelo Cazon,<<MailTo( sandman PUNTO net EN gmail PUNTO com)>>,UNCa - Facultad de Tecnologia y Ciencias Aplicadas
+    Sebastián Bassi,  sbassi EN  gmail PUNTO com,Universidad Nacional de Quilmes
+    Sebastián Bassi,  sbassi EN  gmail PUNTO com,UNNOBA
+    Mariano Reingart,  reingart EN  gmail PUNTO com,Universidad de Morón
+    Mariano Reingart,  reingart EN  gmail PUNTO com,Instituto Superior Tecnológico Blaise Pascal
+    Martín Gaitán,  gaitan EN  gmail PUNTO com,Universidad Nacional de Córdoba
+    Federico Vincenti,  federicovincenti EN  gmail PUNTO com,Universidad Católica de Santiago del Estero - Departamento Académico Rafaela
+    Marcos Alcazar,  marcos.alcazar EN  gmail PUNTO com,UTN - Facultad Regional Mendoza
+    Adrian Pardini,  pardo PUNTO bsso EN  gmail PUNTO com,UNLP Ingeniería
+    Matías Herranz,  matiasherranz EN  gmail PUNTO com,UNC (Universidad Nacional de Córdoba)
+    Ezequiel Chan,  ezequielchan EN  gmail PUNTO com,Universidad Nacional de Luján
+    Julian Cardonnet,  jcardonnet EN  gmail PUNTO com,Universidad Nacional del Centro - Ingenieria de Sistemas (Tandil)
+    Manuel Aráoz,  manuelaraoz EN  gmail PUNTO com,ITBA
+    Juan José Conti,  jjconti EN  gmail PUNTO com,"UTN FRSF, UNL, UCSF"
+    Jose Maria Schenone,  jomax EN  filo.uba PUNTO ar,Filosofia y Letras
+    Alejandro Autalan,  alejandroautalan EN  gmail PUNTO com,Universidad Nacional de Santiago del Estero (UNSE)
+    Daniel Ceillan,  codigodaniel EN  gmail PUNTO com,Cri - Usal (Mar del Plata)
+    Claudio Freire,  klaussfreire EN  gmail PUNTO com,UBA (ciudad universitaria)
+    Samanta Fernandez,  samanta.fernandez EN  gmail PUNTO com,"UTN - FRCU (C. del Uruguay, Entre Ríos)"
+    Juan Martin Muguerza,  juanma EN  gnutn PUNTO org PUNTO ar,UTN Facultad Regional Buenos Aires
+    Agustin Henze,  agustinhenze EN  gmail PUNTO com,UTN Regional Córdoba
+    Daniel F. Moisset,  dmoisset EN  machinalis PUNTO com,"FaMAF, Univ. Nac. de Córdoba"
+    Andres Pardini,  unpardos EN  gmail PUNTO com,UNLP facultad informatica
+    Santiago Banchero,  santiagobanchero EN  gmail PUNTO com,Universidad Nacional de Luján (Centro Regional Chivilcoy)
+    Diego Gaspar,  armandogaspar EN  gmail PUNTO com,Universidad Nacional de Cuyo y otros
+    Gonzalo Fernandez,  buurentriko EN  gmail PUNTO com,Universidad Nacional de Rio Cuarto
+    Ignacio Fiandrino,  tucumetal EN  gmail PUNTO com,Universidad Nacional de Rio Cuarto
+    Gonzalo Delgado,  gonzalodel EN  gmail PUNTO com,Universidad Nacional de Tucumán (Facultad de Ciencias Exactas y Tecnología); Universidad Tecnológica Nacional (Facultad Regional Tucumán)
+    Alejandro Santos,  alejolp EN  alejolp PUNTO com PUNTO ar,UNLP
+    Pereyra Carlos,  pereyra-carlos EN  hotmail PUNTO com,UTN FRLP
+    Rafael Moyano,  moyanor EN  gmail PUNTO com,Universidad Nacional de La Rioja
+    Pablo Papes,  pablopapes EN  gmail PUNTO com,UTN FRCU
+    Manuel Muradás,  mmuradas EN  dieresys PUNTO com PUNTO ar,UADE
+    Manuel Muradás,  mmuradas EN  dieresys PUNTO com PUNTO ar,"""José Hernandez"" E.E.T. Nº7 de Avellaneda"
+    Diego Mascialino,  dmascialino EN  gmail PUNTO com,"UBA - Facultad de Ingeniería, Biblioteca ""Ing Butty"" y Biblioteca del LABI"
+    Emiliano López,  emiliano.lopez EN  gmail PUNTO com,"Universidad Nacional del Litoral (SFe) - Facultad de Ingeniería y Ciencias Hídricas, Facultad de Ingeniería Química"
+    Marcelo Cazon, sandman PUNTO net EN gmail PUNTO com,UNCa - Facultad de Tecnologia y Ciencias Aplicadas
 
 
 Para más información, escribe a la ListaDeCorreo_

--- a/pages/RemerasV3/pedidos.rst
+++ b/pages/RemerasV3/pedidos.rst
@@ -10,18 +10,18 @@ Pedidos Remeras V3 (diseño del Zen) PyConAr
 .. csv-table::
     :header: Nombre,Cantidad/Talle/Color/corte,Modo de entrega,Observaciones
 
-    Roberto L. Bozzacchi,1 M (hombre) Azul Marino,Contra-Reebolso,<<MailTo(robbie ARROBA metasigno PUNTO com)>>
-    Guido Accardo,1 L (hombre) Negro,Contra-Reebolso,<<MailTo(gaccardo ARROBA gmail PUNTO com)>>
-    Marcelo Martinovic,2 XL (hombre) Negro / Blanco,Contra-Reebolso,<<MailTo(marcelo.martinovic ARROBA gmail PUNTO com)>>
-    Martin Alderete,2 S (hombre) Arena / Gris oscuro,Contra-Reebolso,<<MailTo(malderete ARROBA gmail PUNTO com)>>
-    NahuelDefossé,1 XL (hombre) Negra / 1 Xl (hombre) Azul Marino,Contrareembolso/Envío,<<MailTo(nahuel PUNTO defosse ARROBA gmail PUNTO com)>>
-    RamiroAlgozino,"1 S (hombre) Azul Marino (si no hay azul, cualquier color)",encomienda previo depósito,<<MailTo(algozino ARROBA gmail PUNTO com)>>
-    Martín Cerdeira,1 M (hombre) Azul Marino,Contra-Reebolso,<<MailTo(martincerdeira ARROBA gmail PUNTO com)>>
-    Natalia Villegas,1 M (mujer) Arena,Contra-Reembolso,<<MailTo(villegasnaty ARROBA gmail PUNTO com)>>
-    Claudia Quispe,1 S (mujer) Blanco,Contra-Reembolso,<<MailTo(clauva83 ARROBA gmail PUNTO com)>>
-    Juan Manuel García,1 XL (hombre) Azul Francia,Contra-Reembolso,<<MailTo(jmg.utn ARROBA gmail PUNTO com)>>
-    PabloPetenello,1 XL (hombre) Negra / 1 Xl (hombre) Amarillo,Contrareembolso/Envío,<<MailTo(pablopetenello ARROBA gmail PUNTO com)>>
-    Marco Mansilla,5 XXL (hombre) Negra / Amarillo / Gris Oscuro / Rojo / Gris Claro,Contrareembolso,<<MailTo(big ARROBA esdebian PUNTO org)>>
+    Roberto L. Bozzacchi,1 M (hombre) Azul Marino,Contra-Reebolso,robbie ARROBA metasigno PUNTO com
+    Guido Accardo,1 L (hombre) Negro,Contra-Reebolso,gaccardo ARROBA gmail PUNTO com
+    Marcelo Martinovic,2 XL (hombre) Negro / Blanco,Contra-Reebolso,marcelo.martinovic ARROBA gmail PUNTO com
+    Martin Alderete,2 S (hombre) Arena / Gris oscuro,Contra-Reebolso,malderete ARROBA gmail PUNTO com
+    NahuelDefossé,1 XL (hombre) Negra / 1 Xl (hombre) Azul Marino,Contrareembolso/Envío,nahuel PUNTO defosse ARROBA gmail PUNTO com
+    RamiroAlgozino,"1 S (hombre) Azul Marino (si no hay azul, cualquier color)",encomienda previo depósito,algozino ARROBA gmail PUNTO com
+    Martín Cerdeira,1 M (hombre) Azul Marino,Contra-Reebolso,martincerdeira ARROBA gmail PUNTO com
+    Natalia Villegas,1 M (mujer) Arena,Contra-Reembolso,villegasnaty ARROBA gmail PUNTO com
+    Claudia Quispe,1 S (mujer) Blanco,Contra-Reembolso,clauva83 ARROBA gmail PUNTO com
+    Juan Manuel García,1 XL (hombre) Azul Francia,Contra-Reembolso,jmg.utn ARROBA gmail PUNTO com
+    PabloPetenello,1 XL (hombre) Negra / 1 Xl (hombre) Amarillo,Contrareembolso/Envío,pablopetenello ARROBA gmail PUNTO com
+    Marco Mansilla,5 XXL (hombre) Negra / Amarillo / Gris Oscuro / Rojo / Gris Claro,Contrareembolso,big ARROBA esdebian PUNTO org
 
 Pedidos Remeras V3b (Diseño Boa - las remeras celestes del Staff de PyConAr)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -33,10 +33,10 @@ Estas remeras las haremos sólo en 2 colores: celestes con impresión azul (como
 .. csv-table::
     :header: Nombre,Cantidad/Talle/Color/corte,Modo de entrega,Observaciones
 
-    Alejandro Pereira,1 XL (hombre) Arena con impresión Marrón,Contra-Reebolso,<<MailTo(alepereira86 EN gmail PUNTO com)>>
-    Natalia Villegas,1 M (mujer) Celeste con impresión azul,Contra-Reembolso,<<MailTo(villegasnaty EN gmail PUNTO com)>>
-    Facundo Casco,1 M (hombre) Celeste con impresión azul,Contra-Reembolso,<<MailTo(fcasco EN gmail PUNTO com)>>
-    Marcelo Martinovic,1 XL (hombre) Celeste con impresión azul,Contra-Reembolso,<<MailTo(marcelo PUNTO martinovic EN gmail PUNTO com)>>
+    Alejandro Pereira,1 XL (hombre) Arena con impresión Marrón,Contra-Reebolso,alepereira86 EN gmail PUNTO com
+    Natalia Villegas,1 M (mujer) Celeste con impresión azul,Contra-Reembolso,villegasnaty EN gmail PUNTO com
+    Facundo Casco,1 M (hombre) Celeste con impresión azul,Contra-Reembolso,fcasco EN gmail PUNTO com
+    Marcelo Martinovic,1 XL (hombre) Celeste con impresión azul,Contra-Reembolso,marcelo PUNTO martinovic EN gmail PUNTO com
 
 FAQs
 ----

--- a/pages/alfonsopalomares.rst
+++ b/pages/alfonsopalomares.rst
@@ -26,7 +26,7 @@ Conocimientos de Informática:
 
 Vivo en el oeste del gran Buenos Aires, en San Justo.
 
-Email: ``<<MailTo(la_palomares EN yahoo PUNTO es`` )>>
+Email: ``la_palomares EN yahoo PUNTO es`` 
 
 -------------------------
 

--- a/pages/callforcharlas.rst
+++ b/pages/callforcharlas.rst
@@ -16,7 +16,7 @@ A estas organizaciones simplemente se las copia en el mail de call for charlas, 
 .. csv-table::
     :header: Organizacion,Mail
 
-    PyAr,<<MailTo(pyar AT python DOT org DOT ar)>>
+    PyAr,pyar AT python DOT org DOT ar
 
 Template Mail Call For Charlas
 ------------------------------
@@ -35,8 +35,8 @@ Template de Call For Charlas Organizacion
 .. csv-table::
 	:header: Organizacion,Mail,Nombre del Contacto
 
-	Ascentio Technologies,<<MailTo(jproyector AT ascentio DOT com DOT ar)>>,Javier Proyector
-	IBM R&D Argentina,<<MailTo(silvergate-team AT wwpdl DOT vnet DOT ibm DOT com)>>,Silvergate Team
-	Intel Argentina,<<MailTo(fernando.l.patrito AT intel DOT com)>>,"Patrito, Fernando L"
+	Ascentio Technologies,jproyector AT ascentio DOT com DOT ar,Javier Proyector
+	IBM R&D Argentina,silvergate-team AT wwpdl DOT vnet DOT ibm DOT com,Silvergate Team
+	Intel Argentina,fernando.l.patrito AT intel DOT com,"Patrito, Fernando L"
 
 .. _pyday: /pyday

--- a/pages/chistes.rst
+++ b/pages/chistes.rst
@@ -29,7 +29,7 @@ En la presentacion del blog propio de PyWars
 ::
 
    Santiago Suarez Ordoñez wrote:
-   > On Tue, Oct 21, 2008 at 12:59 PM, Enrique Martín <<<MailTo(enri57ar EN gmail PUNTO com)>>> wrote:
+   > On Tue, Oct 21, 2008 at 12:59 PM, Enrique Martín <enri57ar EN gmail PUNTO com> wrote:
    >
    >> Para cuando la lista de correos propia de Pywars?
    >> No sabes a cuantos les va a encantar esa idea.
@@ -44,7 +44,7 @@ En la presentacion del blog propio de PyWars
 
 ::
 
-   On Tue, Oct 14, 2008 at 9:24 PM, John Rowland Lenton <<<MailTo(john EN except PUNTO com PUNTO ar)>>> wrote:
+   On Tue, Oct 14, 2008 at 9:24 PM, John Rowland Lenton <john EN except PUNTO com PUNTO ar> wrote:
    > On Tue, Oct 14, 2008 at 08:07:53PM -0300, Juanjo Conti wrote:
    >> Aja... ya veo, el truco consiste en volver a yieldear cualquier yield
    >> encapsulado :)

--- a/pages/colaborandoenelwiki.rst
+++ b/pages/colaborandoenelwiki.rst
@@ -46,11 +46,11 @@ Cuando Agregamos direcciones de mail conviene usar el macro MailTo, que evita qu
 
     {{{
     #!code moin
-    <<MailTo(joac ARROBA NO QUIERO SPAM algundominio GUION otrodominio PUNTO com)>>
+    joac ARROBA NO QUIERO SPAM algundominio GUION otrodominio PUNTO com
     }}}
 
 Y queda:
-<<MailTo(joac ARROBA NO QUIERO SPAM algundominio GUION otrodominio PUNTO com)>>
+joac ARROBA NO QUIERO SPAM algundominio GUION otrodominio PUNTO com
 
 
 Mas Funcionalidades Copadas

--- a/pages/edupython.rst
+++ b/pages/edupython.rst
@@ -17,12 +17,12 @@ Lista de participantes
 .. csv-table::
     :header: Nombre,Contacto,Ciudad
 
-    Arturo Elias Antón,<<MailTo(arturoeanton EN gmail PUNTO com)>>,Bs.As. Cap Fed
-    Nicolás Pace,<<MailTo(nicopace EN gmail PUNTO com)>>,Bahía Blanca
+    Arturo Elias Antón,arturoeanton EN gmail PUNTO com,Bs.As. Cap Fed
+    Nicolás Pace,nicopace EN gmail PUNTO com,Bahía Blanca
     Gabriel Brunacci,gbrunacci ashoba gmail poonto com,Bs.As. Cap Fed
-    Javier Castrillo,<<MailTo(riverplatense EN gmail PUNTO com)>>,Carapachay
+    Javier Castrillo,riverplatense EN gmail PUNTO com,Carapachay
     Matias Gieco,matigro acávaelarroba gmail acávaelpunto com,"Paraná, Entre Ríos"
-    MarianoReingart|Mariano Reingart,<<MailTo(mariano EN nsis PUNTO com PUNTO ar)>>,Bs.As. Hurlingham
+    MarianoReingart|Mariano Reingart,mariano EN nsis PUNTO com PUNTO ar,Bs.As. Hurlingham
 
 
 Lista de tareas

--- a/pages/eventos/Reuniones/2006/reunion17.rst
+++ b/pages/eventos/Reuniones/2006/reunion17.rst
@@ -60,16 +60,16 @@ Los ganadores fueron:
 .. csv-table::
     :header:Pos,Premio,Ganador,Estado
 
-    01,Vaso térmico,<<MailTo(lorena DOT giraldo AT gmail DOT com)>>,*
-    02,Remera !PyCon 2005 XL,<<MailTo(anifeno AT ubbi DOT com)>>,
-    03,Remera !PyCon 2005 XL,<<MailTo(conan AT lugmen DOT org DOT ar)>>,*
-    04,Remera !PyCon 2005 XL,<<MailTo(paburinu DOT san AT gmail DOT com)>>,
-    05,Remera !PyCon 2005 L,<<MailTo(pablot AT gmail DOT com)>>,
-    06,Remera !PyCon 2005 L,<<MailTo(pablodcar AT gmail DOT com)>>,*
-    07,Remera !PyCon 2005 L,<<MailTo(javierder AT gmail DOT com)>>,
-    08,Remera !PyCon 2005 L,<<MailTo(lucas AT lunix DOT com DOT ar)>>,*
-    09,Remera !PyCon 2006 XL,<<MailTo(enriqueaguerre AT gmail DOT com)>>,
-    10,Bolsa !PyCon 2006,<<MailTo(gepatino AT gmail DOT com)>>,-
+    01,Vaso térmico,lorena DOT giraldo AT gmail DOT com,*
+    02,Remera !PyCon 2005 XL,anifeno AT ubbi DOT com,
+    03,Remera !PyCon 2005 XL,conan AT lugmen DOT org DOT ar,*
+    04,Remera !PyCon 2005 XL,paburinu DOT san AT gmail DOT com,
+    05,Remera !PyCon 2005 L,pablot AT gmail DOT com,
+    06,Remera !PyCon 2005 L,pablodcar AT gmail DOT com,*
+    07,Remera !PyCon 2005 L,javierder AT gmail DOT com,
+    08,Remera !PyCon 2005 L,lucas AT lunix DOT com DOT ar,*
+    09,Remera !PyCon 2006 XL,enriqueaguerre AT gmail DOT com,
+    10,Bolsa !PyCon 2006,gepatino AT gmail DOT com,-
 
 * Los marcados con `-` son los que ya retiraron su premio.
 

--- a/pages/interesadosentrabajo.rst
+++ b/pages/interesadosentrabajo.rst
@@ -21,7 +21,7 @@ Si usted se inscribe acá probablemente reciba emails contactándolo.
 	RobertoRodríguez,,,Capital Federal y GBA
 	RenzoCarbonara,,,Freelance
 	EstebanFeldman,Sí,No,
-	EstebanKüber <<MailTo(ekuber EN gmail PUNTO com)>>,,,Capital Federal
+	EstebanKüber ekuber EN gmail PUNTO com,,,Capital Federal
 	PabloZiliani,,,
 	RicardoD.Quiroga,,,
 	Pedro Guridi,,,"Capital Federal, trabajo remotamente."
@@ -29,10 +29,10 @@ Si usted se inscribe acá probablemente reciba emails contactándolo.
 	AlbertoPaparelli,,,"Capital Federal, GBA Zona Sur"
 	ManuelQuiñones,Sí,No,"Santa Fe, Trabajo remotamente"
 	MartinAlderete,Sí,No,Trabajo remotamente
-	MartinGalan - <<MailTo(chinomng EN gmail PUNTO com)>>,Sí,No,"Santa Fe, trabajo remotamente"
-	Canicue  - <<MailTo(canicue EN gmail PUNTO com)>>,Sí,No,"Mar del Plata,trabajo remotamente"
+	MartinGalan - chinomng EN gmail PUNTO com,Sí,No,"Santa Fe, trabajo remotamente"
+	Canicue  - canicue EN gmail PUNTO com,Sí,No,"Mar del Plata,trabajo remotamente"
 	EzequielMarquez,,,"S.M. de Tucumán, trabajo remotamente"
-	Daniel Ceillan  - <<MailTo(codigodaniel EN gmail PUNTO com)>>,Sí,Sí,"Disponible para viajar, europa preferentemente."
+	Daniel Ceillan  - codigodaniel EN gmail PUNTO com,Sí,Sí,"Disponible para viajar, europa preferentemente."
 	AdrianPardini,Si,Si,Preferentemente teletrabajo. Zona La Plata
 	MartinChikilian,Sí,No,"Córdoba, trabajo remotamente"
 

--- a/pages/manuelquinones.rst
+++ b/pages/manuelquinones.rst
@@ -1,3 +1,3 @@
 == manuel quiñones - manuq ==
-<<MailTo(manuel PUNTO por PUNTO aca EN gmail PUNTO com)>>
+manuel PUNTO por PUNTO aca EN gmail PUNTO com
 

--- a/pages/marcelofernandez.rst
+++ b/pages/marcelofernandez.rst
@@ -2,7 +2,7 @@
 
 Miembro de PyAr desde... qué se yo, 2006 digamos.
 
-Email: <<MailTo(marcelo.fidel.fernandez AT SPAMFREE gmail DOT com)>>
+Email: marcelo.fidel.fernandez AT SPAMFREE gmail DOT com
 
 Pueden encontrar experimentos, comentarios, investigación, en mi blog: http://blog.marcelofernandez.info
 

--- a/pages/mauricio jos(c3a920)tobares.rst
+++ b/pages/mauricio jos(c3a920)tobares.rst
@@ -1,6 +1,6 @@
 == Mauricio José Tobares ==
 
-Email: Contacto: <<MailTo(carrozadelamuerte@gmail.com)>>
+Email: Contacto: carrozadelamuerte@gmail.com
 ## You can even more obfuscate your email address by adding more uppercase letters followed by a leading and trailing blank.
 
 Mi nombre como habrán podido darse cuenta es Mauricio José Tobares, soy argentino, de la ciudad de Baradero en la provincia de buenos aires y ando por estos lados en busca de aprender, no solo una aventura sino que quiero HACER ALGO UTIL con lo que aprenda, vengo del mundo del php puro y duro y nunca es malo tener mas opciones en las cuales desempeñarse

--- a/pages/tracebackinternationalizationproposal.rst
+++ b/pages/tracebackinternationalizationproposal.rst
@@ -5,7 +5,7 @@
    Title: Traceback internationalization
    Version: $Revision$
    Last-Modified: $Date$
-   Author: Mariano Reingart <<<MailTo(reingart EN gmail PUNTO com)>>>
+   Author: Mariano Reingart <reingart EN gmail PUNTO com>
    Status: Draft
    Type: Standards Track
    Content-Type: text/plain


### PR DESCRIPTION
Se saco la directiva `MailTo` que no existe en rST y que fue un problema de la migracion.

Soluciona #69 

@eamanu   por si lo queres revisar