### PR TITLE
Corregir redacción inconsistente

### DIFF
--- a/pages/index.rst
+++ b/pages/index.rst
@@ -3,7 +3,7 @@
 * `Quiénes Somos`_
     Información general sobre que es Python Argentina
 * Eventos_
-    Aquí encontrarás información sobre las actividades que realizamos.
+    Información sobre las actividades que realizamos.
 * `Foro y Redes`_
 	Información sobre el foro (nuestro principal canal de comunicación) y otras redes sociales.
 * Proyectos_


### PR DESCRIPTION
Varios de los demás items en el índice comparten un estilo de redacción
"información sobre...", pero este en particular tenía un estilo
inconsistente sin motivo obvio.