### PR TITLE
Solo un worker de uwsgi

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,9 @@ FROM tiangolo/uwsgi-nginx-flask:python3.9
 
 RUN apt-get update && apt-get install -y rsync
 
+ENV UWSGI_CHEAPER 1
+ENV UWSGI_PROCESSES 2
+
 COPY requirements.txt /tmp/requirements_wiki.txt
 RUN pip install --no-cache-dir -r /tmp/requirements_wiki.txt
 


### PR DESCRIPTION
Cuando se levanta la wiki, se  estan levantando dos workers de uWSGI. 

Creo que por eso hay un race condition de cuando se hace un `git pull` or `nikola build`. La idea es levantar un solo worker para ver si eso soluciona el problema