### PR TITLE
Point to Google fonts via HTTPS

### DIFF
--- a/themes/pyar/assets/css/custom.css
+++ b/themes/pyar/assets/css/custom.css
@@ -1,5 +1,5 @@
-@import url(http://fonts.googleapis.com/css?family=Ubuntu+Mono:400,400italic,700);
-@import url(http://fonts.googleapis.com/css?family=Roboto:400,700);
+@import url(https://fonts.googleapis.com/css?family=Ubuntu+Mono:400,400italic,700);
+@import url(https://fonts.googleapis.com/css?family=Roboto:400,700);
 
 /*
  * General


### PR DESCRIPTION
Required due to Firefox and Chrome blocking mixed content, preventing fonts from being downloaded