### PR TITLE
quitar enlace a Planeta y agregar enlace a Asoc. Civil

### DIFF
--- a/themes/pyar/templates/base.tmpl
+++ b/themes/pyar/templates/base.tmpl
@@ -42,11 +42,11 @@
                     <a class="nav-link" href="http://www.python.org.ar/eventos/"><span class="eventos"></span>Eventos</a>
                 </li>
                 <li class="nav-item">
-                    <a class="nav-link" href="http://planeta.python.org.ar/"><span class="pyar"></span>Planeta</a>
-                </li>
-                <li class="nav-item">
                     <a class="nav-link" href="http://www.python.org.ar/trabajo/"><span class="jobs"></span>Trabajos</a>
                 </li>
+                <li class="nav-item">
+                    <a class="nav-link" href="https://ac.python.org.ar/"><span class="quienes_somos"></span>Asoc. Civil</a>
+                </li>                
             </ul>
         </div>
     </nav> 


### PR DESCRIPTION

![imagen](https://github.com/PyAr/wiki/assets/20157878/366f4cd9-40b8-42fa-a0fc-f9381765d292)

arregla #158 