### PR TITLE
Cambiar el orden de las ediciones para que quede lo más nuevo arriba #165

### DIFF
--- a/pages/gsoc.rst
+++ b/pages/gsoc.rst
@@ -6,7 +6,7 @@
    :width: 80 px
 
 TL;DR:
- * Los **Entusiastas** reciben **becas** para contribuir programando **código abierto**, ver `Ideas <https://github.com/PyAr/wiki/tree/master/pages/GSoC>`_
+ * Los **Entusiastas** reciben **becas** para contribuir programando **código abierto**, ver `Ideas`_
  * Los **Proyectos** encuentran nuevos colaboradores y **mentorean** la nueva generación de desarrolladores
 
 .. class:: alert alert-info
@@ -18,7 +18,6 @@ Enlaces rápidos:
 ================
 
  * `Ideas`_
-
  * `Año 2024`_
  * `Año 2023`_
  * `Año 2022`_
@@ -92,7 +91,7 @@ Si quieres participar como becario colaborador, por favor sigue los siguientes l
    Presentate en el canal de `GSoC Python Arg (público) <https://t.me/+ljnpIYBUMLI3MDAx>`_ mencionando:
 
    * ¿Por qué querés participar del GSoC?, brevemente comenta tu experiencia y expectativas
-   * ¿Qué proyecto preferirías?: revisa la página de `ideas <https://github.com/PyAr/wiki/tree/master/pages/GSoC>`_
+   * ¿Qué proyecto preferirías?: revisa la página de `ideas`_
    * ¿Cuál es tu experiencia previa?, habilidades Python, django, hg/git, js, etc.
 
 2. **¡Corrige un bug!**
@@ -223,8 +222,8 @@ Blogs y Referencias sobre el GSoC
 * PSF 2007: http://pyfound.blogspot.com/2007/03/psf-and-googles-summer-of-code.html
 
 .. _Ideas: /GSoC/ideas
-.. _2024: /GSoC/2024
-.. _2023: /GSoC/2023
-.. _2022: /GSoC/2022
-.. _2019: /GSoC/2019
+.. _Año 2024: /GSoC/2024
+.. _Año 2023: /GSoC/2023
+.. _Año 2022: /GSoC/2022
+.. _Año 2019: /GSoC/2019
 .. _marianoreingart: /marianoreingart

--- a/pages/pycamp.rst
+++ b/pages/pycamp.rst
@@ -45,74 +45,58 @@ La próxima edición está en marcha_
 Ediciones anteriores
 --------------------
 
-* Primera edición, Los Cocos, Córdoba. Marzo de 2008.
-
-* Segunda edición, `Los Cocos, Córdoba. Marzo de 2009`_.
-
-* Tercera edición, `Veronica, Buenos Aires. Marzo de 2010`_.
-
-* Cuarta edición, `La Falda, Córdoba. Marzo de 2011`_.
-
-* Quinta edición, `Veronica, Buenos Aires. Julio de 2012`_.
-
-* Sexta edición, `Villa Giardino, Córdoba. Junio de 2013`_.
-
-* Séptima edición, `Villa Giardino, Córdoba. Marzo de 2014`_.
-
-* Octava edición `La Serranita, Córdoba. Agosto de 2015`_
-
-* Novena edición `La Serranita, Córdoba. Marzo de 2016`_
-
-* Décima edición `Baradero, Buenos Aires. Marzo de 2017`_
-
-* Decimoprimera edición `Baradero, Buenos Aires. Abril de 2018`_
-
-* Decimosegunda edición `San Rafael, Mendoza. Marzo de 2019`_
-
-* Decimotercera edición `San Rafael, Mendoza. Noviembre de 2021`_
-
-* Decimocuarta edición `Baradero, Buenos Aires. Marzo de 2022`_
+* Decimosexta edición `Riachuelo, Corrientes. Junio de 2024`_
 
 * Decimoquinta edición `Riachuelo, Corrientes. Marzo de 2023`_
 
-* Decimosexta edición `Riachuelo, Corrientes. Junio de 2024`_
+* Decimocuarta edición `Baradero, Buenos Aires. Marzo de 2022`_
+
+* Decimotercera edición `San Rafael, Mendoza. Noviembre de 2021`_
+
+* Decimosegunda edición `San Rafael, Mendoza. Marzo de 2019`_
+
+* Decimoprimera edición `Baradero, Buenos Aires. Abril de 2018`_
+
+* Décima edición `Baradero, Buenos Aires. Marzo de 2017`_
+
+* Novena edición `La Serranita, Córdoba. Marzo de 2016`_
+
+* Octava edición `La Serranita, Córdoba. Agosto de 2015`_
+
+* Séptima edición, `Villa Giardino, Córdoba. Marzo de 2014`_.
+
+* Sexta edición, `Villa Giardino, Córdoba. Junio de 2013`_.
+
+* Quinta edición, `Veronica, Buenos Aires. Julio de 2012`_.
+
+* Cuarta edición, `La Falda, Córdoba. Marzo de 2011`_.
+
+* Tercera edición, `Veronica, Buenos Aires. Marzo de 2010`_.
+
+* Segunda edición, `Los Cocos, Córdoba. Marzo de 2009`_.
+
+* Primera edición, Los Cocos, Córdoba. Marzo de 2008.
 
 
 Blogpost sobre Pycamps
 ----------------------
 
-2008
+2024
 ~~~~
 
-* FacundoBatista_: http://www.taniquetil.com.ar/plog/post/1/329
+* HugoRuscitti_: https://www.examplelab.com.ar/posts/2024-06-30-creando-retro-python-en-el-pycamp/
 
-* Dieresys: http://blog.dieresys.com.ar/2008/02/16/live-from-pycamp-2008/
+* OSiUX : https://osiux.com/2024-06-20-pycamp-2024-en-corrientes.html
 
-2009
+2023
 ~~~~
 
-* RamiroMorales_: http://rmorales.com.ar/blog/2009/03/30/pycamp-2009-de-pyar/
+* OSiUX : https://osiux.com/2023-03-27-pycamp-2023-en-corrientes.html
 
-* Linux-Os.com.ar: http://www.linux-os.com.ar/linuxos/python-pycamp-2009-cordoba/
-
-* FacundoBatista_: http://www.taniquetil.com.ar/plog/post/1/404
-
-* MarcosDione_: http://grulicueva.homelinux.net/~mdione/glob/posts/pycamp-2009/
-
-2010
+2022
 ~~~~
 
-* django.es: http://django.es/blog/sprint-django-pycamp-argentina-2009/
-
-* GonzaloOdiard: http://godiard.blogspot.com/2010/03/en-el-pycamp.html
-
-* JohnLenton_: http://pyvore.com/2010/03/10/pycamp.html
-
-* FacundoBatista_: http://www.taniquetil.com.ar/plog/post/1/452
-
-* JoaquinSorianello_: http://www.joaclandia.com.ar/2010/03/buenas-nuevas.html
-
-* TomasZulberti: http://www.tzulberti.com.ar/2010/04/17/pycamp-2010/
+* OSiUX : https://osiux.com/2022-03-28-pycamp-2022-en-baradero.html
 
 2011
 ~~~~
@@ -133,6 +117,39 @@ Blogpost sobre Pycamps
 
 * EmilianoDallaVerdeMarcozzi_: http://ninjasandpythones.blogspot.com/2011/04/experiencia-del-pycamp-en-la-falda.html
 
+2010
+~~~~
+
+* django.es: http://django.es/blog/sprint-django-pycamp-argentina-2009/
+
+* GonzaloOdiard: http://godiard.blogspot.com/2010/03/en-el-pycamp.html
+
+* JohnLenton_: http://pyvore.com/2010/03/10/pycamp.html
+
+* FacundoBatista_: http://www.taniquetil.com.ar/plog/post/1/452
+
+* JoaquinSorianello_: http://www.joaclandia.com.ar/2010/03/buenas-nuevas.html
+
+* TomasZulberti: http://www.tzulberti.com.ar/2010/04/17/pycamp-2010/
+
+2009
+~~~~
+
+* RamiroMorales_: http://rmorales.com.ar/blog/2009/03/30/pycamp-2009-de-pyar/
+
+* Linux-Os.com.ar: http://www.linux-os.com.ar/linuxos/python-pycamp-2009-cordoba/
+
+* FacundoBatista_: http://www.taniquetil.com.ar/plog/post/1/404
+
+* MarcosDione_: http://grulicueva.homelinux.net/~mdione/glob/posts/pycamp-2009/
+
+2008
+~~~~
+
+* FacundoBatista_: http://www.taniquetil.com.ar/plog/post/1/329
+
+* Dieresys: http://blog.dieresys.com.ar/2008/02/16/live-from-pycamp-2008/
+
 .. ############################################################################
 
 
@@ -140,43 +157,43 @@ Blogpost sobre Pycamps
 
 .. _organizar: /PyCamp/organizandounpycamp
 
-.. _marcha: /PyCamp/2023
+.. _marcha: /PyCamp/2024
 
-.. _Cocos2d: http://cocos2d.org/
+.. _Cocos2d: https://pypi.org/project/cocos2d/
 
 .. _lalita: http://launchpad.net/lalita
 
 .. _CDpedia: http://code.google.com/p/cdpedia/
 
-.. _Los Cocos, Córdoba. Marzo de 2009: /PyCamp/2009
-
-.. _Veronica, Buenos Aires. Marzo de 2010: /PyCamp/2010
-
-.. _La Falda, Córdoba. Marzo de 2011: /PyCamp/2011
-
-.. _Veronica, Buenos Aires. Julio de 2012: /PyCamp/2012
-
-.. _Villa Giardino, Córdoba. Junio de 2013: /PyCamp/2013
-
-.. _Villa Giardino, Córdoba. Marzo de 2014: /PyCamp/2014
-
-.. _La Serranita, Córdoba. Agosto de 2015: /PyCamp/2015
-
-.. _La Serranita, Córdoba. Marzo de 2016: /PyCamp/2016
-
-.. _Baradero, Buenos Aires. Marzo de 2017: /PyCamp/2017
-
-.. _Baradero, Buenos Aires. Abril de 2018: /PyCamp/2018
-
-.. _San Rafael, Mendoza. Marzo de 2019: /PyCamp/2019
-
-.. _San Rafael, Mendoza. Noviembre de 2021: /PyCamp/2021
-
-.. _Baradero, Buenos Aires. Marzo de 2022: /PyCamp/2022
+.. _Riachuelo, Corrientes. Junio de 2024: /PyCamp/2024
 
 .. _Riachuelo, Corrientes. Marzo de 2023: /PyCamp/2023
 
-.. _Riachuelo, Corrientes. Junio de 2024: /PyCamp/2024
+.. _Baradero, Buenos Aires. Marzo de 2022: /PyCamp/2022
+
+.. _San Rafael, Mendoza. Noviembre de 2021: /PyCamp/2021
+
+.. _San Rafael, Mendoza. Marzo de 2019: /PyCamp/2019
+
+.. _Baradero, Buenos Aires. Abril de 2018: /PyCamp/2018
+
+.. _Baradero, Buenos Aires. Marzo de 2017: /PyCamp/2017
+
+.. _La Serranita, Córdoba. Marzo de 2016: /PyCamp/2016
+
+.. _La Serranita, Córdoba. Agosto de 2015: /PyCamp/2015
+
+.. _Villa Giardino, Córdoba. Marzo de 2014: /PyCamp/2014
+
+.. _Villa Giardino, Córdoba. Junio de 2013: /PyCamp/2013
+
+.. _Veronica, Buenos Aires. Julio de 2012: /PyCamp/2012
+
+.. _La Falda, Córdoba. Marzo de 2011: /PyCamp/2011
+
+.. _Veronica, Buenos Aires. Marzo de 2010: /PyCamp/2010
+
+.. _Los Cocos, Córdoba. Marzo de 2009: /PyCamp/2009
 
 .. _ramiromorales: /ramiromorales
 .. _marcosdione: /marcosdione


### PR DESCRIPTION
Cambiar el orden de las ediciones para que quede lo más nuevo arriba. Agregar enlaces a Blogpost y ordenarlos para que quede el último arriba de todo. Enlace a cocos2d.

![imagen](https://github.com/PyAr/wiki/assets/20157878/b713d795-9181-4fe0-921b-bcee6d7997f8)


